### PR TITLE
Support externally-defined volumes

### DIFF
--- a/mainnet/docker-compose.yml
+++ b/mainnet/docker-compose.yml
@@ -68,23 +68,11 @@ services:
 
 volumes:
   bitcoin:
-    driver: local
-    driver_opts:
-      type: none
-      device: /private/var/lib/bitcoin
-      o: bind
+      external: "${BITCOIN_VOLUME_EXTERNAL:-false}"
   elements:
-    driver: local
-    driver_opts:
-      type: none
-      device: /private/var/lib/elements
-      o: bind
+      external: "${ELEMENTS_VOLUME_EXTERNAL:-false}"
   electrs:
-    driver: local
-    driver_opts:
-      type: none
-      device: /private/var/lib/electrs
-      o: bind
+      external: "${ELECTRS_VOLUME_EXTERNAL:-false}"
 
 networks:
   bitcoinrpc:


### PR DESCRIPTION
The goal here is to have something that can either work "out of the box" for less experienced people, while also allowing to set custom volume paths without having to touch the docker compose file, if the user wants to do so.

To do this, we set the `external` option to either the value of an env variable (if present) or `false` by default. Whenever someone runs `docker-compose up` with no other option, it will default to "false" and it will automatically create the volumes in the correct place for the platform that's running docker. At the same time, a more advanced user can set the `{BITCOIN,ELEMENTS,ELECTRS}_VOLUME_EXTERNAL` variables to `true` (all of them, or even some of them, it doesn't matter). When `external` is `true` for a specific volume, docker expects the user to manually create the volume with whatever options it wants. It also gives a nice clear error message, like this:

```
$ BITCOIN_VOLUME_EXTERNAL=true  docker-compose up
ERROR: Volume bitcoin declared as external, but could not be found. Please create the volume manually using `docker volume create --name=bitcoin` and try again.
```

I think this is a better approach than the one described in #5, since it doesn't require the user to choose the right env file for its platform and copy it in the right place.