### PR TITLE
fix electrs entrypoint in Dockerfile

### DIFF
--- a/Dockerfile/electrs/Dockerfile
+++ b/Dockerfile/electrs/Dockerfile
@@ -65,6 +65,6 @@ USER electrs:electrs
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["electrs", "--daemon-dir /var/lib/bitcoin", "--db-dir /var/lib/electrs"]
+ENTRYPOINT ["electrs", "--daemon-dir", "/var/lib/bitcoin", "--db-dir", "/var/lib/electrs"]
 
 CMD ["-vvvv"]


### PR DESCRIPTION
this fixes the following error message that electrs was logging:
`Error: An unknown argument '--daemon-dir /var/lib/bitcoin' was specified.`

more info on why we need to separate rust flags from application-specific ones: https://doc.rust-lang.org/cargo/commands/cargo-run.html#description