### PR TITLE
Electrs cookie file

### DIFF
--- a/Dockerfile/electrs-signet/Dockerfile
+++ b/Dockerfile/electrs-signet/Dockerfile
@@ -44,7 +44,7 @@ RUN groupadd -r electrs && useradd -r -m -g electrs electrs \
     && chmod 700 "$ELECTRS_DATA" \
     && chown -R electrs:electrs "$ELECTRS_DATA"
 
-VOLUME "/var/lib/bitcoind"
+VOLUME "/var/lib/bitcoin"
 VOLUME "/var/lib/electrs"
 
 # Electrum X RPC port for signet

--- a/Dockerfile/electrs-signet/Dockerfile
+++ b/Dockerfile/electrs-signet/Dockerfile
@@ -38,10 +38,6 @@ COPY --from=builder /usr/local/cargo/bin/electrs /usr/local/bin
 
 ENV BITCOIN_DATA=/var/lib/bitcoin
 ENV ELECTRS_DATA=/var/lib/electrs
-ENV ELECTRS_CONF=/etc/electrs/electrs.toml
-
-RUN mkdir /etc/electrs
-RUN echo 'cookie = "bitcoin:bitcoin"' > $ELECTRS_CONF
 
 RUN groupadd -r electrs && useradd -r -m -g electrs electrs \
     && mkdir -p "$ELECTRS_DATA" \
@@ -59,4 +55,4 @@ EXPOSE 34224
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/electrs -vvvv --network signet --daemon-dir $BITCOIN_DATA --db-dir $ELECTRS_DATA --conf $ELECTRS_CONF "]
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/electrs -vvvv --network signet --daemon-dir $BITCOIN_DATA --db-dir $ELECTRS_DATA "]

--- a/Dockerfile/electrs/Dockerfile
+++ b/Dockerfile/electrs/Dockerfile
@@ -44,9 +44,6 @@ ARG DATA_DIR=/var/lib/electrs
 
 COPY --from=builder /usr/local/cargo/bin/electrs $BIN_DIR
 
-RUN mkdir /etc/electrs \
-    && echo 'cookie = "bitcoin:bitcoin"' > /etc/electrs/config.toml
-
 RUN groupadd -r electrs && useradd -r -m -g electrs electrs \
     && mkdir -p "$DATA_DIR" \
     && chmod 700 "$DATA_DIR" \

--- a/docker-compose/mainnet/docker-compose.yml
+++ b/docker-compose/mainnet/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       ELECTRS_DAEMON_RPC_ADDR: "bitcoind-mainnet:8332"
       ELECTRS_ELECTRUM_RPC_ADDR: "electrs-mainnet:50001"
       ELECTRS_MONITORING_ADDR: "electrs-mainnet:4224"
+      ELECTRS_COOKIE_FILE: "/var/lib/bitcoin/.cookie"
     expose:
       - 4224
     ports:

--- a/docker-compose/signet/docker-compose.yml
+++ b/docker-compose/signet/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       ELECTRS_DAEMON_RPC_ADDR: "bitcoind-signet:38332"
       ELECTRS_ELECTRUM_RPC_ADDR: "electrs-signet:60601"
       ELECTRS_MONITORING_ADDR: "electrs-signet:34224"
+      ELECTRS_COOKIE_FILE: "/var/lib/bitcoin/signet/.cookie"
     ports:
       - 60601:60601
     expose:

--- a/docker-compose/testnet/docker-compose.yml
+++ b/docker-compose/testnet/docker-compose.yml
@@ -32,6 +32,7 @@ services:
       ELECTRS_DAEMON_RPC_ADDR: "bitcoind-testnet:18332"
       ELECTRS_ELECTRUM_RPC_ADDR: "electrs-testnet:60001"
       ELECTRS_MONITORING_ADDR: "electrs-testnet:14223"
+      ELECTRS_COOKIE_FILE: "/var/lib/bitcoin/testnet3/.cookie"
     ports:
       - 60001:60001
     expose:


### PR DESCRIPTION
this PR refers to the task "_More safe RPC interfaces (with macaroons/cookie files) not exposed to the external world_" defined in #20

it changes how electrs authenticates to bitcoind, using the recommended way described [here](https://github.com/romanz/electrs/blob/master/doc/usage.md#bitcoind-configuration): _The highly recommended way of authenticating electrs is using cookie file._